### PR TITLE
Ignore root self

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ var transform = transformTools.makeRequireTransform(
 
       files = Object.keys(myGlob.matches[0]);
 
-      var requireArgs = [];
+      var requireArgs = [],
+          selfFile = myGlob.found[0];
       files.forEach(function(file) {
+        if(file === selfFile) { return; }
         requireArgs.push("require('" + file + "')");
       });
 


### PR DESCRIPTION
Added a check to ensure the rootFile or "selfFile" isn't included in the globbing. There may be a better approach, but this resolves the root file/directory from trying to include itself which previously resulted in error.